### PR TITLE
20 Parse Anderswo-Titles as Markdown without breaking the slug in anchortags

### DIFF
--- a/src/routes/timeline/[topic]/[year]/+page.svelte
+++ b/src/routes/timeline/[topic]/[year]/+page.svelte
@@ -7,6 +7,7 @@
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import Dot from './Dot.svelte';
 	import { colors } from '$lib/metadata.json';
+	import { parse } from 'marked';
 
 	const images: any = import.meta.glob(['$lib/images/timeline/**.jpg'], {
 		eager: true,
@@ -39,7 +40,7 @@
 					href="{base}/detail/{encodeURIComponent(item)}_{data.year}"
 				>
 					<Dot size={24} color="black" />
-					<span>{item}</span>
+					<span>{@html parse(item)}</span>
 				</a>
 			{/each}
 		</div>


### PR DESCRIPTION
https://github.com/DHBern/NMB-mercenaries/issues/20

See e.g. http://localhost:5173/timeline/Heilmann/1816 to check.